### PR TITLE
Set up automated release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,9 +2,12 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,6 +22,7 @@ jobs:
         with:
           release-type: python
           token: ${{ secrets.GITHUB_TOKEN }}
+          release-as: ${{ inputs.version }}
 
       # The following steps only run if a release was created
       - name: Checkout code


### PR DESCRIPTION
Changed release-please workflow to only run manually via workflow_dispatch. Added required version input parameter to allow specifying release version. This prevents automatic releases on push to main and gives full control over when releases are created.