### PR TITLE
fix: ensure --email-stdout only outputs MIME email, not regular report

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -47,4 +47,4 @@ verbose = false
 DB_FILE = "cwatch.db"
 output_format = "text"  # Options: text, json, html
 # output_file = "report.html"  # Optional: write to file instead of stdout
-# To output email format to stdout (useful for cron): use --email-stdout flag
+# For cron: use --email-stdout flag to output multipart MIME email

--- a/src/cwatch/cw.py
+++ b/src/cwatch/cw.py
@@ -517,19 +517,19 @@ def main() -> None:
     reporter = get_reporter(report_format, conf)
     report = reporter.generate(collected_data)
 
-    # Output report to stdout/file
-    output_destination = conf["cwatch"].get("output_file")
-    if output_destination:
-        with open(output_destination, "w") as f:
-            f.write(report)
-    else:
-        print(report)
-
-    # Handle email output
+    # Handle email output (for cron)
     if args.email_stdout:
         from cwatch.email_sender import output_email_to_stdout  # noqa: PLC0415
 
         output_email_to_stdout(conf, collected_data)
+    else:
+        # Output report to stdout/file
+        output_destination = conf["cwatch"].get("output_file")
+        if output_destination:
+            with open(output_destination, "w") as f:
+                f.write(report)
+        else:
+            print(report)
 
     # Exit code based on results
     sys.exit(0 if collected_data.successful > 0 else 1)

--- a/src/cwatch/email_sender.py
+++ b/src/cwatch/email_sender.py
@@ -10,7 +10,7 @@ def output_email_to_stdout(configuration: dict, collected_data: CollectedData) -
     """Output email report to stdout as multipart MIME message.
 
     Creates a proper multipart/alternative email with both text and HTML versions
-    that can be piped to sendmail or similar tools.
+    suitable for cron jobs (cron will automatically email the output).
 
     Args:
         configuration: Configuration dictionary


### PR DESCRIPTION
When using --email-stdout flag, skip the regular report output and only output the multipart MIME email. This ensures cron receives clean email output without duplicate content.

Changes:
- Skip regular report output when --email-stdout is enabled
- Only output MIME email when flag is set
- Update documentation to clarify cron usage
- Remove references to piping to sendmail (cron handles this automatically)

Usage:
  cwatch                # Normal report output
  cwatch --email-stdout # MIME email output only (for cron)